### PR TITLE
Restrict offset logic result inputs to integers

### DIFF
--- a/src/AlreadyGetNeededCountException.php
+++ b/src/AlreadyGetNeededCountException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SomeWork/OffsetPage/Logic package.
  *

--- a/src/Offset.php
+++ b/src/Offset.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SomeWork/OffsetPage/Logic package.
  *
@@ -23,12 +25,8 @@ class Offset
      *
      * @return OffsetLogicResult
      */
-    public static function logic($offset, $limit, $nowCount = 0)
+    public static function logic(int $offset, int $limit, int $nowCount = 0): OffsetLogicResult
     {
-        $offset = (int) $offset;
-        $limit = (int) $limit;
-        $nowCount = (int) $nowCount;
-
         $offset = $offset >= 0 ? $offset : 0;
         $limit = $limit >= 0 ? $limit : 0;
         $nowCount = $nowCount >= 0 ? $nowCount : 0;

--- a/src/OffsetLogicException.php
+++ b/src/OffsetLogicException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SomeWork/OffsetPage/Logic package.
  *

--- a/src/OffsetLogicResult.php
+++ b/src/OffsetLogicResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SomeWork/OffsetPage/Logic package.
  *
@@ -13,57 +15,36 @@ namespace SomeWork\OffsetPage\Logic;
 
 class OffsetLogicResult
 {
-    /**
-     * @var int
-     */
-    protected $page;
-    /**
-     * @var int
-     */
-    protected $size;
+    protected int $page = 0;
 
-    public function __construct($page = 0, $size = 0)
+    protected int $size = 0;
+
+    public function __construct(int $page = 0, int $size = 0)
     {
         $this->setPage($page);
         $this->setSize($size);
     }
 
-    /**
-     * @return int
-     */
-    public function getPage()
+    public function getPage(): int
     {
         return $this->page;
     }
 
-    /**
-     * @param int $page
-     *
-     * @return $this
-     */
-    public function setPage($page)
+    public function setPage(int $page): self
     {
-        $this->page = (int) $page >= 0 ? (int) $page : 0;
+        $this->page = $page >= 0 ? $page : 0;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getSize()
+    public function getSize(): int
     {
         return $this->size;
     }
 
-    /**
-     * @param int $size
-     *
-     * @return $this
-     */
-    public function setSize($size)
+    public function setSize(int $size): self
     {
-        $this->size = (int) $size > 0 ? (int) $size : 0;
+        $this->size = $size > 0 ? $size : 0;
 
         return $this;
     }

--- a/tests/OffsetLogicResultTest.php
+++ b/tests/OffsetLogicResultTest.php
@@ -32,7 +32,7 @@ class OffsetLogicResultTest extends TestCase
 
     public function testWrongCreate()
     {
-        $offsetLogicResult = new OffsetLogicResult('wef', -22);
+        $offsetLogicResult = new OffsetLogicResult(-1, -22);
         $this->assertEquals(0, $offsetLogicResult->getPage());
         $this->assertEquals(0, $offsetLogicResult->getSize());
     }


### PR DESCRIPTION
## Summary
- restrict OffsetLogicResult constructor and setters to integer inputs
- retain non-negative normalization for page and size values
- update tests to cover negative integer initialization

## Testing
- composer test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931299cc3e483208b10d84478aad484)