### PR TITLE
Add strict typing to offset logic result

### DIFF
--- a/src/OffsetLogicResult.php
+++ b/src/OffsetLogicResult.php
@@ -15,11 +15,7 @@ namespace SomeWork\OffsetPage\Logic;
 
 class OffsetLogicResult
 {
-    protected int $page = 0;
-
-    protected int $size = 0;
-
-    public function __construct(int $page = 0, int $size = 0)
+    public function __construct(protected int $page = 0, protected int $size = 0)
     {
         $this->setPage($page);
         $this->setSize($size);

--- a/tests/OffsetLogicResultTest.php
+++ b/tests/OffsetLogicResultTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the SomeWork/OffsetPage/Logic package.
  *


### PR DESCRIPTION
## Summary
- promote OffsetLogicResult page and size to typed constructor properties while preserving normalization
- enable strict types in OffsetLogicResult tests

## Testing
- composer test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312c7186748320a0246bc88d9e8278)