### PR TITLE
Add dependabot and tooling configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ phpunit.phar
 ### Php cs fixer
 .php_cs.cache
 .php-cs-fixer.cache
+
+### Tooling cache
+var/

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
     "phpstan/phpstan": "^1.12",
     "friendsofphp/php-cs-fixer": "^3.91"
   },
-  "scripts": {
+    "scripts": {
     "test": "vendor/bin/phpunit",
-    "stan": "vendor/bin/phpstan analyse src tests",
-    "cs-check": "vendor/bin/php-cs-fixer fix --dry-run --diff",
-    "cs-fix": "vendor/bin/php-cs-fixer fix"
+    "stan": "vendor/bin/phpstan analyse -c phpstan.neon.dist",
+    "cs-check": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff",
+    "cs-fix": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,6 @@
+parameters:
+    level: 1
+    paths:
+        - src
+        - tests
+    tmpDir: var/cache/phpstan


### PR DESCRIPTION
## Summary
- add Dependabot configuration for GitHub Actions and Composer updates
- add minimal PHPStan configuration and composer scripts to use it
- ensure PHP-CS-Fixer runs via composer scripts and cache directories are ignored

## Testing
- composer test
- composer stan
- composer validate

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931312bb2a8832091d0ef8ebb30944c)