### PR TITLE
Fix AlreadyGetNeededCountException message clarity

### DIFF
--- a/src/Offset.php
+++ b/src/Offset.php
@@ -51,7 +51,7 @@ class Offset
                 return static::logic($offset + $nowCount, $limit - $nowCount);
             }
 
-            throw new AlreadyGetNeededCountException('Limit is less than or equal to the current count. You should stop asking (:');
+            throw new AlreadyGetNeededCountException('Limit is less than or equal to the current count. You should stop asking.');
         }
 
         if ($offset > 0 && $limit > 0) {

--- a/tests/OffsetTest.php
+++ b/tests/OffsetTest.php
@@ -308,6 +308,7 @@ class OffsetTest extends TestCase
     public function testNowCountException($offset, $limit, $nowCount)
     {
         $this->expectException(AlreadyGetNeededCountException::class);
+        $this->expectExceptionMessage('Limit is less than or equal to the current count. You should stop asking.');
         Offset::logic($offset, $limit, $nowCount);
     }
 


### PR DESCRIPTION
## Summary
- replace the truncated AlreadyGetNeededCountException message with a single clear string
- assert the expected exception message in the now count exception test

## Testing
- vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693132bc1a6083208d0ff5bbe00afa52)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message clarity by updating exception text.

* **Tests**
  * Updated test assertions to verify the new exception message format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->