### PR TITLE
Update PHP CS Fixer config to PSR-12

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -19,10 +19,12 @@ return (new PhpCsFixer\Config())
     ->setUsingCache(true)
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PSR2' => true,
+        '@PSR12' => true,
         'psr_autoloading' => true,
         'header_comment' => ['header' => $header],
-        'trailing_comma_in_multiline' => true,
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays', 'arguments', 'parameters'],
+        ],
         'cast_spaces' => true,
         'no_unused_imports' => true,
         'include' => true,

--- a/src/Offset.php
+++ b/src/Offset.php
@@ -66,7 +66,7 @@ class Offset
                     if ($offset % $i === 0) {
                         return new OffsetLogicResult(
                             ($offset / $i) + 1,
-                            $i
+                            $i,
                         );
                     }
                 }


### PR DESCRIPTION
## Summary
- update php-cs-fixer configuration to use the PSR-12 ruleset while keeping project-specific header, trailing comma, and unused import rules
- align code formatting with the stricter trailing comma rules required by the updated configuration

## Testing
- composer cs-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931342e7a3c83209f10f2641632c4ea)