### PR TITLE
Remove Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - nightly
-before_script:
-  - composer install


### PR DESCRIPTION
## Summary
- remove the legacy Travis CI configuration file now that GitHub Actions is the sole CI

## Testing
- not run (not needed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931354c06448320b9644496664913e1)