### PR TITLE
Raise PHPStan level and tighten typing

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,5 @@
 parameters:
-    level: 1
+    level: 7
     paths:
         - src
         - tests
-    tmpDir: var/cache/phpstan

--- a/src/Offset.php
+++ b/src/Offset.php
@@ -65,7 +65,7 @@ class Offset
                 for ($i = $limit; $i > 0; $i--) {
                     if ($offset % $i === 0) {
                         return new OffsetLogicResult(
-                            ($offset / $i) + 1,
+                            intdiv($offset, $i) + 1,
                             $i,
                         );
                     }

--- a/tests/OffsetLogicResultTest.php
+++ b/tests/OffsetLogicResultTest.php
@@ -18,35 +18,35 @@ use SomeWork\OffsetPage\Logic\OffsetLogicResult;
 
 class OffsetLogicResultTest extends TestCase
 {
-    public function testDefaultCreate()
+    public function testDefaultCreate(): void
     {
         $offsetLogicResult = new OffsetLogicResult();
         $this->assertEquals(0, $offsetLogicResult->getPage());
         $this->assertEquals(0, $offsetLogicResult->getSize());
     }
 
-    public function testSetOnCreate()
+    public function testSetOnCreate(): void
     {
         $offsetLogicResult = new OffsetLogicResult(4, 20);
         $this->assertEquals(4, $offsetLogicResult->getPage());
         $this->assertEquals(20, $offsetLogicResult->getSize());
     }
 
-    public function testWrongCreate()
+    public function testWrongCreate(): void
     {
         $offsetLogicResult = new OffsetLogicResult(-1, -22);
         $this->assertEquals(0, $offsetLogicResult->getPage());
         $this->assertEquals(0, $offsetLogicResult->getSize());
     }
 
-    public function testPageSet()
+    public function testPageSet(): void
     {
         $offsetLogicResult = new OffsetLogicResult();
         $offsetLogicResult->setPage(5);
         $this->assertEquals(5, $offsetLogicResult->getPage());
     }
 
-    public function testSizeSet()
+    public function testSizeSet(): void
     {
         $offsetLogicResult = new OffsetLogicResult();
         $offsetLogicResult->setSize(6);

--- a/tests/OffsetTest.php
+++ b/tests/OffsetTest.php
@@ -21,6 +21,8 @@ class OffsetTest extends TestCase
 {
     /**
      * @dataProvider limitNowCountProvider
+     *
+     * @param array{page:int, size:int} $expectedResult
      */
     public function testLimitNowCount(int $offset, int $limit, int $nowCount, array $expectedResult): void
     {
@@ -29,6 +31,9 @@ class OffsetTest extends TestCase
         $this->assertEquals($expectedResult['size'], $result->getSize());
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int, expectedResult: array{page:int, size:int}}>
+     */
     public static function limitNowCountProvider(): array
     {
         return [
@@ -64,6 +69,8 @@ class OffsetTest extends TestCase
 
     /**
      * @dataProvider oneMoreThanZeroProvider
+     *
+     * @param array{page:int, size:int} $expectedResult
      */
     public function testOneMoreThanZero(int $offset, int $limit, int $nowCount, array $expectedResult): void
     {
@@ -72,6 +79,9 @@ class OffsetTest extends TestCase
         $this->assertEquals($expectedResult['size'], $result->getSize());
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int, expectedResult: array{page:int, size:int}}>
+     */
     public static function oneMoreThanZeroProvider(): array
     {
         return [
@@ -112,6 +122,8 @@ class OffsetTest extends TestCase
 
     /**
      * @dataProvider offsetZeroProvider
+     *
+     * @param array{page:int, size:int} $expectedResult
      */
     public function testOffsetZero(int $offset, int $limit, int $nowCount, array $expectedResult): void
     {
@@ -120,6 +132,9 @@ class OffsetTest extends TestCase
         $this->assertEquals($expectedResult['size'], $result->getSize());
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int, expectedResult: array{page:int, size:int}}>
+     */
     public static function offsetZeroProvider(): array
     {
         return [
@@ -153,6 +168,8 @@ class OffsetTest extends TestCase
 
     /**
      * @dataProvider limitZeroProvider
+     *
+     * @param array{page:int, size:int} $expectedResult
      */
     public function testLimitZero(int $offset, int $limit, int $nowCount, array $expectedResult): void
     {
@@ -161,6 +178,9 @@ class OffsetTest extends TestCase
         $this->assertEquals($expectedResult['size'], $result->getSize());
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int, expectedResult: array{page:int, size:int}}>
+     */
     public static function limitZeroProvider(): array
     {
         return [
@@ -205,6 +225,8 @@ class OffsetTest extends TestCase
 
     /**
      * @dataProvider limitOffsetMoreThanZeroProvider
+     *
+     * @param array{page:int, size:int} $expectedResult
      */
     public function testLimitOffsetMoreThanZero(int $offset, int $limit, int $nowCount, array $expectedResult): void
     {
@@ -213,6 +235,9 @@ class OffsetTest extends TestCase
         $this->assertEquals($expectedResult['size'], $result->getSize());
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int, expectedResult: array{page:int, size:int}}>
+     */
     public static function limitOffsetMoreThanZeroProvider(): array
     {
         return [
@@ -270,6 +295,9 @@ class OffsetTest extends TestCase
         Offset::logic($offset, $limit, $nowCount);
     }
 
+    /**
+     * @return array<string, array{offset:int, limit:int, nowCount:int}>
+     */
     public static function nowCountExceptionProvider(): array
     {
         return [


### PR DESCRIPTION
## Summary
- raise PHPStan to level 7 and rely on the default cache location
- ensure offset calculation uses integer division to match OffsetLogicResult expectations
- add explicit return types and typed data providers in tests to satisfy stricter analysis

## Testing
- vendor/bin/phpstan analyse
- vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693137c02c048320b9ee122f2ec29de3)