### PR TITLE
Refactor CI workflow into test and quality jobs

### DIFF
--- a/.github/actions/composer-install/action.yml
+++ b/.github/actions/composer-install/action.yml
@@ -1,0 +1,32 @@
+name: Composer install with cache
+description: Set up PHP with Composer and install dependencies using cache
+inputs:
+  php-version:
+    description: PHP version to install
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        coverage: none
+        tools: composer
+
+    - name: Get composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-php-${{ inputs.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ inputs.php-version }}-composer-
+
+    - name: Install dependencies
+      shell: bash
+      run: composer install --no-interaction --no-progress --prefer-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Install dependencies
+        uses: ./.github/actions/composer-install
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: Run tests
         run: composer test
@@ -51,27 +34,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - name: Install dependencies
+        uses: ./.github/actions/composer-install
         with:
           php-version: ${{ matrix.php-version }}
-          coverage: none
-          tools: composer
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: Static analysis
         run: composer stan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
+    strategy: &php-matrix
       fail-fast: false
       matrix:
         php-version: ['8.2', '8.3']
@@ -41,6 +41,37 @@ jobs:
 
       - name: Run tests
         run: composer test
+
+  quality:
+    needs: tests
+    runs-on: ubuntu-latest
+    strategy: *php-matrix
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+          tools: composer
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: Static analysis
         run: composer stan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "master"]
+    branches: ["master"]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Author: [Igor Pinchuk](https://github.com/somework "Github")  
 Email: i.pinchuk.work@gmail.com
 
-[![CI](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml)
+[![CI](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml)
 [![Latest Stable Version](https://img.shields.io/packagist/v/somework/offset-page-logic.svg)](https://packagist.org/packages/somework/offset-page-logic)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Author: [Igor Pinchuk](https://github.com/somework "Github")  
 Email: i.pinchuk.work@gmail.com
 
-[![CI](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/somework/offset-page-logic/ci.yml?branch=master&label=Tests)](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml?query=branch%3Amaster)
+[![Quality](https://img.shields.io/github/actions/workflow/status/somework/offset-page-logic/ci.yml?branch=master&label=Quality)](https://github.com/somework/offset-page-logic/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Latest Stable Version](https://img.shields.io/packagist/v/somework/offset-page-logic.svg)](https://packagist.org/packages/somework/offset-page-logic)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- split CI into separate testing and quality jobs while reusing the PHP version matrix
- keep shared checkout/setup/install steps with caching across both jobs
- run static analysis and coding standards in a dedicated quality job after tests

## Testing
- Not run (workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931415e05dc8320894da5a3985fc899)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow configuration with improved job organization and reusable configuration patterns to enhance development process efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->