### PR TITLE
Add negative offset coercion coverage to tests

### DIFF
--- a/tests/OffsetTest.php
+++ b/tests/OffsetTest.php
@@ -46,6 +46,15 @@ class OffsetTest extends TestCase
                     'size' => 2,
                 ],
             ],
+            'offset<0;limit=5;nowCount=2;' => [
+                'offset'         => -5,
+                'limit'          => 5,
+                'nowCount'       => 2,
+                'expectedResult' => [
+                    'page' => 2,
+                    'size' => 2,
+                ],
+            ],
             'offset=0;limit=5;nowCount=4;' => [
                 'offset'         => 0,
                 'limit'          => 5,
@@ -59,6 +68,15 @@ class OffsetTest extends TestCase
                 'offset'         => 0,
                 'limit'          => 5,
                 'nowCount'       => 0,
+                'expectedResult' => [
+                    'page' => 1,
+                    'size' => 5,
+                ],
+            ],
+            'offset=0;limit=5;nowCount<0;' => [
+                'offset'         => 0,
+                'limit'          => 5,
+                'nowCount'       => -3,
                 'expectedResult' => [
                     'page' => 1,
                     'size' => 5,
@@ -89,6 +107,15 @@ class OffsetTest extends TestCase
                 'offset'         => 0,
                 'limit'          => 0,
                 'nowCount'       => 0,
+                'expectedResult' => [
+                    'page' => 0,
+                    'size' => 0,
+                ],
+            ],
+            'offset<0;limit<0;nowCount<0;' => [
+                'offset'         => -1,
+                'limit'          => -1,
+                'nowCount'       => -1,
                 'expectedResult' => [
                     'page' => 0,
                     'size' => 0,
@@ -163,6 +190,15 @@ class OffsetTest extends TestCase
                     'size' => 10,
                 ],
             ],
+            'offset<0;limit>0;nowCount>0;limit>nowCount;' => [
+                'offset'         => -3,
+                'limit'          => 22,
+                'nowCount'       => 10,
+                'expectedResult' => [
+                    'page' => 2,
+                    'size' => 10,
+                ],
+            ],
         ];
     }
 
@@ -188,6 +224,15 @@ class OffsetTest extends TestCase
                 'offset'         => 22,
                 'limit'          => 0,
                 'nowCount'       => 0,
+                'expectedResult' => [
+                    'page' => 2,
+                    'size' => 22,
+                ],
+            ],
+            'offset>0;limit<0;nowCount<0;'                  => [
+                'offset'         => 22,
+                'limit'          => -10,
+                'nowCount'       => -5,
                 'expectedResult' => [
                     'page' => 2,
                     'size' => 22,
@@ -245,6 +290,15 @@ class OffsetTest extends TestCase
                 'offset'         => 22,
                 'limit'          => 33,
                 'nowCount'       => 0,
+                'expectedResult' => [
+                    'page' => 2,
+                    'size' => 22,
+                ],
+            ],
+            'offset>0;limit>0;nowCount<0;'                                      => [
+                'offset'         => 22,
+                'limit'          => 33,
+                'nowCount'       => -5,
                 'expectedResult' => [
                     'page' => 2,
                     'size' => 22,


### PR DESCRIPTION
## Summary
- add negative offset, limit, and nowCount cases across existing PHPUnit data providers
- verify negative values are coerced to zero while preserving expected OffsetLogicResult outcomes

## Testing
- vendor/bin/phpunit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693154cc5cbc832085c077444dc2a3f0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage to validate edge cases involving negative or zero values in offset and limit parameters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->