### PR TITLE
Update changelog for 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Update this file with each release so adopters and Packagist visitors can track what changed.
 
-## [Unreleased]
-
 ## [2.0.0] - 2025-12-04
 ### Changed
 - Raised the PHP requirement to 8.2 and refreshed development tooling (PHPUnit 10, PHPStan, and PHP CS Fixer) with composer scripts to run tests, static analysis, and coding standards checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [2.0.0] - 2025-12-05
+## [2.0.0] - 2025-12-04
 ### Changed
 - Raised the PHP requirement to 8.2 and refreshed development tooling (PHPUnit 10, PHPStan, and PHP CS Fixer) with composer scripts to run tests, static analysis, and coding standards checks.
 - Enforced integer-only inputs for offset, limit, and nowCount with strict typing while normalizing negative values to zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [2.0.0] - 2025-12-04
+## [2.0.0] - 2025-12-05
 ### Changed
 - Raised the PHP requirement to 8.2 and refreshed development tooling (PHPUnit 10, PHPStan, and PHP CS Fixer) with composer scripts to run tests, static analysis, and coding standards checks.
+- Enforced integer-only inputs for offset, limit, and nowCount with strict typing while normalizing negative values to zero.
+- Clarified the `AlreadyGetNeededCountException` message when the requested limit is already satisfied.
+- Expanded PHPUnit coverage for divisor-loop pagination edges and negative offset/limit inputs.
 - Modernized PHPUnit data providers and exception expectations to clear deprecations when running on PHP 8.2.
 
 ## [1.0.0] - 2017-06-04


### PR DESCRIPTION
## Summary
- set the 2.0.0 entry to the actual release date
- add user-facing highlights covering input typing, exception messaging, and extended tests alongside tooling updates
- retain the Unreleased section for future entries

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69315df706e88320af7f06ab919080f3)